### PR TITLE
Pre-release fixes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,8 +16,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+    # (A checkout is needed for the local test, else you'll see the Error:)
+    # Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
+    # '/home/runner/work/link-checker-gpt/link-checker-gpt/action'. Did you
+    # forget to run actions/checkout before running your local action?
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Check Links using Link Checker Action
       uses: ./action/  # say instead "uses: kingdonb/link-checker-gpt/action@main"
       with:
         token: ${{ secrets.GITHUB_TOKEN }} # pass a github token so we can comment
-        prNumber: ${{ github.event.pull_request.number }} # the current PR number
+        # prNumber: ${{ github.event.pull_request.number }} # the current PR number
+        prNumber: 1573 # We're testing against this PR until the merge is finished

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-This link checker is designed for use with the FluxCD website preview environments:
+# Link-Checker GPT
+
+This link checker is so-named because it was mostly written by ChatGPT.
+
+It is designed for use with the FluxCD website preview environments:
 
 ```ruby
-ruby link_checker.rb deploy-preview-1573--fluxcd.netlify.app
+ruby main.rb deploy-preview-1573--fluxcd.netlify.app
 ```
 
 It may behave differently when run against `fluxcd.io` and the preview site,

--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ At some point this could be improved to work as a CI check, but we will need
 to fix most of the links first, and find a way to make exceptions for any more
 that cannot be fixed.
 
+### Broken feature: Sitemap Caching
+
 There is a cache, so if you have run the script before the "Visiting links"
 step will not be repeated unless you run `make clean` first. This is to help
 with iterative development, since most of the runtime errors come from the
 validate method and anchor checker, they can be debugged easily from a cache.
+
+However, it doesn't work. So make sure if you are running this more than one
+time, you always run at least `make clean-cache` between separate executions.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Assuming it runs to completion, it will produce a report in report.csv
 
 I can import this report into Google Drive and mark it up as I fix the links.
 
-At some point this could be improved to work as a CI check, but we will need
-to fix most of the links first, and find a way to make exceptions for any more
-that cannot be fixed.
+This nearly works as a CI check, but we will need to fix many of the links
+first, and find a way to make exceptions for any more that cannot be fixed.
 
 ### Broken feature: Sitemap Caching
 

--- a/lib/link.rb
+++ b/lib/link.rb
@@ -9,6 +9,10 @@ class Link
     @source_file = source_url
     @domain = domain
 
+    # if @source_file == "https://fluxcd.io/guides/mozilla-sops/#using-various-cloud-providers"
+    #   raise StandardError
+    # end
+
     if link_element
       @link_string = link_element['href']
       link_text = link_element.text

--- a/lib/link/link_analyzer.rb
+++ b/lib/link/link_analyzer.rb
@@ -79,7 +79,7 @@ class LinkAnalyzer
     LINKS_MUTEX.synchronize do
       # Use both the target URL and source URL as the key to ensure uniqueness
       key = "#{source_url}::#{target_url}"
-      links_data[key] ||= Link.new(url, link_element, @domain)
+      links_data[key] ||= Link.new(source_url, link_element, @domain)
       links_data[key]
     end
   end

--- a/lib/link/link_analyzer.rb
+++ b/lib/link/link_analyzer.rb
@@ -75,7 +75,7 @@ class LinkAnalyzer
     end
   end
 
-  def ensure_link(links_data, url, link_element)
+  def ensure_link(links_data, source_url, target_url, link_element)
     LINKS_MUTEX.synchronize do
       # Use both the target URL and source URL as the key to ensure uniqueness
       key = "#{source_url}::#{target_url}"

--- a/lib/link/link_analyzer.rb
+++ b/lib/link/link_analyzer.rb
@@ -79,7 +79,7 @@ class LinkAnalyzer
     LINKS_MUTEX.synchronize do
       # Use both the target URL and source URL as the key to ensure uniqueness
       key = "#{source_url}::#{target_url}"
-      links_data[key] ||= Link.new(source_url, link_element)
+      links_data[key] ||= Link.new(url, link_element, @domain)
       links_data[key]
     end
   end


### PR DESCRIPTION
The key in the links database is a composite of both the link source and the target, so we can catch the same bad link on multiple pages when it occurs at once.

Will continue to add fixes to this branch until it looks like we're catching all the faults, then merge and make a release (0.1.0?)